### PR TITLE
Fix a bug where context menu is added at the start of the selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kognity/vue-yellow-marker",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kognity/vue-yellow-marker",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Adds a text selection and highlighting functionality to your Vue components",
   "main": "./dist/vue-yellow-marker.umd.min.js",
   "scripts": {

--- a/src/highlight-mixin.js
+++ b/src/highlight-mixin.js
@@ -231,11 +231,10 @@ const HighlightMixin = {
     },
     ymAddMenuToSelection(selection, component, actions = {}, props = {}) {
       this.ymRemoveMenu();
-      // Add a range by the end of the selection
-      const { node, offset } = getLatestNode(selection);
-      const range = new Range();
-      range.setStart(node, offset);
-      range.setEnd(node, offset);
+      // Add menu at the end of selected range
+      const { node } = getLatestNode(selection);
+      const range = this.hlRange.cloneRange();
+      range.collapse(false);
       this.hlMenuHookParent = node.parentElement;
       this.hlSelectionMenu = this.ymCreateMenu(component, actions, props);
       const menuElement = this.hlSelectionMenu.$el;


### PR DESCRIPTION
This happens when a user highlights texts and that highlight start at a particular node and end at another node that the child of the former, i.e. when `focusNode` is a child of `anchorNode`.